### PR TITLE
add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "jmuspratt/craft-fieldguide",
+    "authors": [
+        {
+            "name": "James Muspratt",
+            "email": "james@jamesmuspratt.com"
+        }
+    ],
+    "type": "craft-plugin",
+    "require": {
+        "composer/installers": "~1.0"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,8 @@
     "type": "craft-plugin",
     "require": {
         "composer/installers": "~1.0"
+    },
+    "extra": {
+        "installer-name": "fieldguide"
     }
 }


### PR DESCRIPTION
It would be nice to have a composer.json, so we could load in the plugin via https://github.com/composer/installers