### PR TITLE
Removed assumption tablePrefix is always 'craft_'

### DIFF
--- a/fieldguide/FieldGuidePlugin.php
+++ b/fieldguide/FieldGuidePlugin.php
@@ -11,7 +11,7 @@ class FieldGuidePlugin extends BasePlugin
 
 	public function getVersion()
 	{
-		return '1.1';
+		return '1.1.1';
 	}
 
 	public function getDeveloper()

--- a/fieldguide/variables/FieldGuideVariable.php
+++ b/fieldguide/variables/FieldGuideVariable.php
@@ -26,9 +26,9 @@ class FieldGuideVariable {
 		// all field ids
 		$query = craft()->db->createCommand();
 		$allFieldIds = $query
-			->select('craft_fields.id')
+			->select('id')
 			->from('fields')
-			->order('craft_fields.id')
+			->order('id')
 			->queryAll();
 		$allFieldIds = self::array_flatten($allFieldIds);
 		
@@ -36,9 +36,9 @@ class FieldGuideVariable {
 		$query = craft()->db->createCommand();
 		$query->distinct = true;
 		$usedFieldIds = $query
-			->select('craft_fieldlayoutfields.fieldId')
+			->select('fieldId')
 			->from('fieldlayoutfields')
-			->order('craft_fieldlayoutfields.fieldId')
+			->order('fieldId')
 			->queryAll();
 		$usedFieldIds = self::array_flatten($usedFieldIds);
 		


### PR DESCRIPTION
Found that the plugin failed to find the table if tablePrefix had been specified as something other than craft_ in config > db.php